### PR TITLE
Fix Glue table schema block syntax

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,11 +87,18 @@ resource "aws_glue_catalog_table" "table" {
       serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
       parameters = { "serialization.format" = "1" }
     }
-    columns = [
-      { name = "id",    type = "int"    },
-      { name = "name",  type = "string" },
-      { name = "value", type = "double" }
-    ]
+    columns {
+      name = "id"
+      type = "int"
+    }
+    columns {
+      name = "name"
+      type = "string"
+    }
+    columns {
+      name = "value"
+      type = "double"
+    }
   }
   parameters = { EXTERNAL = "TRUE", classification = "parquet", "parquet.compression" = "SNAPPY" }
 }


### PR DESCRIPTION
## Summary
- replace deprecated columns argument with columns blocks in Glue table storage descriptor

## Testing
- terraform validate *(fails: terraform not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b2de3218833086c23d27410e38c0